### PR TITLE
Fix phpunit source build folder configuration

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -133,7 +133,7 @@ module.exports = function(grunt) {
 			},
 			'npm-packages': {
 				files: {
-					'build/wp-includes/js/backbone.min.js': ['./node_modules/backbone/backbone-min.js'],
+					'build/wp-includes/js/backbone.js': ['./node_modules/backbone/backbone.js'],
 					'build/wp-includes/js/hoverIntent.js': ['./node_modules/jquery-hoverintent/jquery.hoverIntent.js'],
 					'build/wp-includes/js/imagesloaded.min.js': ['./node_modules/imagesloaded/imagesloaded.pkgd.min.js'],
 					'build/wp-includes/js/jquery/jquery-migrate.js': ['./node_modules/jquery-migrate/dist/jquery-migrate.js'],

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -32,6 +32,10 @@ if ( ! is_readable( $config_file_path ) ) {
 require_once $config_file_path;
 require_once dirname( __FILE__ ) . '/functions.php';
 
+if ( file_exists( ABSPATH . '_index.php' ) ) {
+	exit( 'Please configure ABSPATH to point to the `build` directory instead of the `src` directory.' );
+}
+
 tests_reset__SERVER();
 
 define( 'WP_TESTS_TABLE_PREFIX', $table_prefix );

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -33,6 +33,7 @@ require_once $config_file_path;
 require_once dirname( __FILE__ ) . '/functions.php';
 
 if ( file_exists( ABSPATH . '_index.php' ) ) {
+	// Perhaps add more documentation about having to run `grunt` before running tests after changing code.
 	exit( 'Please configure ABSPATH to point to the `build` directory instead of the `src` directory.' );
 }
 

--- a/wp-tests-config-sample.php
+++ b/wp-tests-config-sample.php
@@ -1,7 +1,7 @@
 <?php
 
 /* Path to the WordPress codebase you'd like to test. Add a forward slash in the end. */
-define( 'ABSPATH', dirname( __FILE__ ) . '/src/' );
+define( 'ABSPATH', dirname( __FILE__ ) . '/build/' );
 
 /*
  * Path to the theme to test with.


### PR DESCRIPTION
This PR changes the default configuration of the `ABSPATH` constant to point to the `build` directory.

There needs to be mention about having to run `grunt build` before running the tests after modifying any code (PHP or JavaScript).

An extra check for the introduced `_index.php` file has been added to the PHPUnit bootstrap file, because the default configuration suggested to configure the `ABSPATH` to the `src` folder, so developers will have this configured already.

The tests will not run when this configuration is used.